### PR TITLE
GDC-684: Барчарт вертикальный. Неверные отступы между барами, если нет группировки

### DIFF
--- a/src/_private/components/BarChart/__tests__/index.test.ts
+++ b/src/_private/components/BarChart/__tests__/index.test.ts
@@ -336,7 +336,7 @@ describe('getGridSettings', () => {
         gridTemplateRows: 'auto 1fr auto',
         gridTemplateColumns:
           'auto' +
-          ' minmax(calc((var(--column-size) * 3) + (var(--column-padding) * 3)), 1fr)'.repeat(3),
+          ' minmax(calc((var(--column-size) * 3) + (var(--column-padding) * 2)), 1fr)'.repeat(3),
         gridTemplateAreas:
           '"topLeft labelTop0 labelTop1 labelTop2" ' +
           '"leftTicks group0 group1 group2" ' +
@@ -358,7 +358,7 @@ describe('getGridSettings', () => {
         gridTemplateRows: 'auto 1fr auto',
         gridTemplateColumns:
           'auto' +
-          ' minmax(calc((var(--column-size) * 3) + (var(--column-padding) * 3)), 1fr)'.repeat(3),
+          ' minmax(calc((var(--column-size) * 3) + (var(--column-padding) * 2)), 1fr)'.repeat(3),
         gridTemplateAreas:
           '"topLeft labelTop0 labelTop1 labelTop2" ' +
           '"leftTicks group0 group1 group2" ' +
@@ -380,7 +380,7 @@ describe('getGridSettings', () => {
         gridTemplateRows: 'auto 1fr auto auto',
         gridTemplateColumns:
           'auto' +
-          ' minmax(calc((var(--column-size) * 3) + (var(--column-padding) * 3)), 1fr)'.repeat(3),
+          ' minmax(calc((var(--column-size) * 3) + (var(--column-padding) * 2)), 1fr)'.repeat(3),
         gridTemplateAreas:
           '"topLeft labelTop0 labelTop1 labelTop2" ' +
           '"leftTicks group0 group1 group2" ' +
@@ -403,7 +403,7 @@ describe('getGridSettings', () => {
         gridTemplateRows: 'auto 1fr auto auto',
         gridTemplateColumns:
           'auto' +
-          ' minmax(calc((var(--column-size) * 3) + (var(--column-padding) * 3)), 1fr)'.repeat(3),
+          ' minmax(calc((var(--column-size) * 3) + (var(--column-padding) * 2)), 1fr)'.repeat(3),
         gridTemplateAreas:
           '"topLeft labelTop0 labelTop1 labelTop2" ' +
           '"leftTicks group0 group1 group2" ' +

--- a/src/_private/components/BarChart/components/Group/index.css
+++ b/src/_private/components/BarChart/components/Group/index.css
@@ -2,9 +2,6 @@
 @custom-selector :--vertical-group .group:not(.isHorizontal);
 
 .group {
-  /* Используется в отступе для первой и последней группы */
-  --group-outer-padding: var(--space-3xs);
-
   display: flex;
   flex-grow: 1;
 

--- a/src/_private/components/BarChart/helpers.ts
+++ b/src/_private/components/BarChart/helpers.ts
@@ -202,7 +202,8 @@ export const getGridSettings = ({
         gridTemplateColumns: `auto ${getAreaNames(
           countGroups,
           () =>
-            `minmax(calc((var(--column-size) * ${maxColumn}) + (var(--column-padding) * ${maxColumn})), 1fr)`
+            `minmax(calc((var(--column-size) * ${maxColumn}) + (var(--column-padding) * ${maxColumn -
+              1})), 1fr)`
         )}`,
         gridTemplateAreas:
           `"topLeft ${getAreaNames(countGroups, index => `labelTop${index}`)}" ` +

--- a/src/_private/components/BarChart/renders.tsx
+++ b/src/_private/components/BarChart/renders.tsx
@@ -55,27 +55,4 @@ export type RenderGroup<T> = (props: {
   onChangeLabelSize?: (size: number) => void
 }) => React.ReactNode
 
-const getGroupStyles = ({
-  isHorizontal,
-  isFirst,
-  isLast,
-}: {
-  isHorizontal: boolean
-  isFirst: boolean
-  isLast: boolean
-}) => ({
-  ...(!isHorizontal && isFirst ? { paddingLeft: 'var(--group-outer-padding)' } : {}),
-  ...(!isHorizontal && isLast ? { paddingRight: 'var(--group-outer-padding)' } : {}),
-  ...(isHorizontal && isFirst ? { paddingTop: 'var(--group-outer-padding)' } : {}),
-  ...(isHorizontal && isLast ? { paddingBottom: 'var(--group-outer-padding)' } : {}),
-})
-
-export const defaultRenderGroup: RenderGroup<GroupItem> = props => {
-  const style = getGroupStyles({
-    isHorizontal: props.isHorizontal,
-    isFirst: props.isFirst,
-    isLast: props.isLast,
-  })
-
-  return <Group {...props} style={style} />
-}
+export const defaultRenderGroup: RenderGroup<GroupItem> = Group


### PR DESCRIPTION
## Чек-лист
- [ ] Используется calc-size(), где он нужен
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [x] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение
