### PR TITLE
GDC-685: Барчарт горизонтальный. Неверные отступы между барами, если нет группировки

### DIFF
--- a/src/_private/components/BarChart/components/Ticks/index.tsx
+++ b/src/_private/components/BarChart/components/Ticks/index.tsx
@@ -30,7 +30,6 @@ type Props<T> = {
   | {
       isLabel: true
       getGridAreaName: (index: number) => string
-      isDense?: boolean
     }
   | {
       isLabel?: never
@@ -146,7 +145,7 @@ export function Ticks<T>(props: Props<T>) {
           align={textAlign}
           title={textValue}
           className={classnames(css.text)}
-          lineHeight={props.isLabel && props.isDense ? 's' : undefined}
+          lineHeight="s"
         >
           {(isXAxisLabelsSlanted && (
             <span ref={refs[idx]}>{cropText(textValue, SLANTED_TEXT_MAX_LENGTH)}</span>

--- a/src/_private/components/BarChart/index.tsx
+++ b/src/_private/components/BarChart/index.tsx
@@ -229,7 +229,6 @@ export const CoreBarChart = <T,>(props: Props<T>) => {
       values: groupsDomain,
       position,
       size: columnSize,
-      isDense,
       getGridAreaName: getLabelGridAreaName(position),
       isXAxisLabelsSlanted,
     })
@@ -244,7 +243,6 @@ export const CoreBarChart = <T,>(props: Props<T>) => {
         scaler: valuesScale,
         position,
         size: columnSize,
-        isDense,
         formatValueForLabel,
       })}
     </div>

--- a/src/_private/components/BarChart/renders.tsx
+++ b/src/_private/components/BarChart/renders.tsx
@@ -14,7 +14,6 @@ export type RenderGroupsLabels = (props: {
   values: readonly string[]
   position: Position
   size: Size
-  isDense: boolean
   isXAxisLabelsSlanted?: boolean
   getGridAreaName: (index: number) => string
 }) => React.ReactNode
@@ -28,7 +27,6 @@ export type RenderAxisValues = (props: {
   scaler: Scaler<number>
   position: Position
   size: Size
-  isDense: boolean
   formatValueForLabel?: FormatValue
 }) => React.ReactNode
 


### PR DESCRIPTION
* привёл line-height лэйблов в соответствие с макетом

## Чек-лист
- [ ] Используется calc-size(), где он нужен
- [x] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [ ] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение
