### PR TITLE
GDC-668: Сборка компонентов: Улучшить минификацию

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,9 +9,7 @@ module.exports = {
     [
       require('babel-preset-minify'),
       {
-        builtIns: false,
-        evaluate: false,
-        mangle: false,
+        builtIns: false  // // FIXME проблема с babel-plugin-minify-builtins, апдейтнуть когда пофиксят https://github.com/babel/minify/issues/904
       },
     ],
   ],


### PR DESCRIPTION
Провел сравнение подходов(Common/Parsed/Gzipped):

babel-preset-minify без babel-minify-builtins-plugin - 95/72.3/22.2 кб
terser - 94.3/72.5/22.3 кб
Смысла менять нету, хотя и babel-preset-minify немного хуже поддерживается

## Чек-лист
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [ ] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение
