### PR TITLE
GDC-832: Опубликовать react-textfit в npm и подключить в виджетах

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@amcharts/amcharts4-geodata": "4.1.9",
     "@consta/widgets-utils": "0.2.14",
+    "@evless/react-textfit": "1.1.1",
     "@types/d3": "5.7.2",
     "@types/resize-observer-browser": "0.1.2",
     "classnames": "2.2.6",
@@ -71,7 +72,6 @@
     "lodash": "4.17.19",
     "react-dnd": "9.3.2",
     "react-dnd-html5-backend": "9.3.2",
-    "react-textfit": "https://github.com/al-fyodorov/react-textfit#v1.1.1",
     "react-uid": "2.2.0"
   },
   "resolutions": {

--- a/src/_private/components/DonutChart/components/Text/index.tsx
+++ b/src/_private/components/DonutChart/components/Text/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { Textfit } from 'react-textfit'
 
 import { isDefined, isNotNil } from '@consta/widgets-utils/lib/type-guards'
+import { Textfit } from '@evless/react-textfit'
 import classnames from 'classnames'
 
 import {

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -62,7 +62,7 @@ declare module '*.geojson' {
   export = content
 }
 
-declare module 'react-textfit' {
+declare module '@evless/react-textfit' {
   import React from 'react'
 
   type TextfitProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,6 +2542,14 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@evless/react-textfit@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@evless/react-textfit/-/react-textfit-1.1.1.tgz#e581e739618350d8f35c2430e95a72ac18565537"
+  integrity sha512-RV1XKlBJCzxrvvEXGkBn9quaIIttPnE5Glfrdw+6YzlOI2Yje1rE+VECl3NaP8LZTWxBZ+VYoHOEgl7t7K7LyQ==
+  dependencies:
+    process "^0.11.9"
+    prop-types "^15.5.10"
+
 "@hot-loader/react-dom@16.8.6":
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.8.6.tgz#7923ba27db1563a7cc48d4e0b2879a140df461ea"
@@ -15156,13 +15164,6 @@ react-textarea-autosize@^7.1.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
-
-"react-textfit@https://github.com/al-fyodorov/react-textfit#v1.1.1":
-  version "1.1.1"
-  resolved "https://github.com/al-fyodorov/react-textfit#81e650632e25cfacf21d3d62088b3674e39cd50b"
-  dependencies:
-    process "^0.11.9"
-    prop-types "^15.5.10"
 
 react-transition-group@^2.2.1:
   version "2.9.0"


### PR DESCRIPTION
## Чек-лист
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [ ] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение
