### PR TITLE
GDC-532: Роадмап. Тултип обрезается на невысоком окне (ждет переноса тултипа)

### DIFF
--- a/src/Roadmap/components/RoadmapTooltip/index.tsx
+++ b/src/Roadmap/components/RoadmapTooltip/index.tsx
@@ -125,9 +125,19 @@ export const RoadmapTooltip: React.FC<Props> = ({
       ref={ref}
       direction="upRight"
       size="l"
-      possibleDirections={['downLeft', 'downRight', 'upLeft', 'upRight']}
+      possibleDirections={[
+        'downLeft',
+        'downRight',
+        'upLeft',
+        'upRight',
+        'downStartLeft',
+        'downStartRight',
+        'upStartLeft',
+        'upStartRight',
+      ]}
       position={position}
       onClickOutside={onRequestClose}
+      spareDirection="downStartLeft"
     >
       <Dates color={color} title={title} fact={fact} plan={plan} forecast={forecast} />
       <Comment comment={comment} />


### PR DESCRIPTION
## Чек-лист
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [ ] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение
