### PR TITLE
TRIVIAL: Добавил декоратор документации 

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,3 @@
-import { DocsContainer } from '@storybook/addon-docs/blocks'
 import { withKnobs } from '@storybook/addon-knobs'
 import { withInfo } from '@storybook/addon-info'
 import { addDecorator, addParameters } from '@storybook/react'
@@ -6,17 +5,9 @@ import { themes } from '@storybook/theming'
 import { withPropsTable } from 'storybook-addon-react-docgen'
 
 import { environmentDecorator, listOfThemes, ThemeDecorator } from '@/_private/storybook'
+import { DocsDecorator } from '@/_private/storybook/decorators/DocsContainer'
 
 import stub from './stub.mdx'
-
-import '@consta/uikit/__internal__/src/components/Theme/Theme.css'
-import '@consta/uikit/__internal__/src/components/Theme/_color/Theme_color_gpnDisplay.css'
-import '@consta/uikit/__internal__/src/components/Theme/_color/Theme_color_gpnDark.css'
-import '@consta/uikit/__internal__/src/components/Theme/_color/Theme_color_gpnDefault.css'
-import '@consta/uikit/__internal__/src/components/Theme/_control/Theme_control_gpnDefault.css'
-import '@consta/uikit/__internal__/src/components/Theme/_font/Theme_font_gpnDefault.css'
-import '@consta/uikit/__internal__/src/components/Theme/_size/Theme_size_gpnDefault.css'
-import '@consta/uikit/__internal__/src/components/Theme/_space/Theme_space_gpnDefault.css'
 
 import './storybook.css'
 
@@ -35,7 +26,7 @@ addParameters({
     Decorator: ThemeDecorator,
   },
   docs: {
-    container: DocsContainer,
+    container: DocsDecorator,
     page: stub,
   },
   options: {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     ]
   },
   "peerDependencies": {
-    "@consta/uikit": "1.10.1",
+    "@consta/uikit": "1.10.2",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },

--- a/src/BackgroundBarChart/__stories__/docs.mdx
+++ b/src/BackgroundBarChart/__stories__/docs.mdx
@@ -1,0 +1,31 @@
+import { SimpleExample } from './examples/SimpleExample'
+
+# BackgroundBarChart
+
+Документация
+
+<SimpleExample />
+
+## Свойства
+
+<!-- props:start -->
+
+| Свойство          | Тип      | По умолчанию | Описание |
+| ----------------- | -------- | ------------ | -------- |
+| [`prop`](#ссылка) | `string` | -            | Описание |
+| `prop`            | `string` | -            | Описание |
+
+```tsx
+export const SimpleExample = () => (
+  <div className={classnames(css.main)}>
+    <BackgroundBarChart
+      groups={groups}
+      gridTicks={4}
+      valuesTicks={1}
+      isHorizontal={true}
+      showValues={false}
+      align="start"
+    />
+  </div>
+)
+```

--- a/src/BackgroundBarChart/__stories__/examples/SimpleExample/index.css
+++ b/src/BackgroundBarChart/__stories__/examples/SimpleExample/index.css
@@ -1,0 +1,3 @@
+.main {
+  margin-top: var(--space-m);
+}

--- a/src/BackgroundBarChart/__stories__/examples/SimpleExample/index.tsx
+++ b/src/BackgroundBarChart/__stories__/examples/SimpleExample/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import classnames from 'classnames'
+
+import { BackgroundBarChart } from '../../..'
+import { groups } from '../../../data.mock'
+
+import css from './index.css'
+
+export const SimpleExample = () => (
+  <div className={classnames(css.main)}>
+    <BackgroundBarChart
+      groups={groups}
+      gridTicks={4}
+      valuesTicks={1}
+      isHorizontal={true}
+      showValues={false}
+      align="start"
+    />
+  </div>
+)

--- a/src/BackgroundBarChart/__stories__/index.stories.tsx
+++ b/src/BackgroundBarChart/__stories__/index.stories.tsx
@@ -4,8 +4,10 @@ import { boolean, number, object, select, text } from '@storybook/addon-knobs'
 
 import { createMetadata, createStory, environmentDecorator } from '@/_private/storybook'
 
-import { aligns, BackgroundBarChart } from '.'
-import { groups } from './data.mock'
+import { aligns, BackgroundBarChart } from '..'
+import { groups } from '../data.mock'
+
+import docs from './docs.mdx'
 
 const getCommonProps = (initialUnit: string) => {
   const unit = text('unit', initialUnit)
@@ -30,6 +32,9 @@ export default createMetadata({
   title: 'components/BackgroundBarChart',
   decorators: [environmentDecorator()],
   parameters: {
+    docs: {
+      page: docs,
+    },
     environment: {
       style: {
         width: '40vw',

--- a/src/Roadmap/index.tsx
+++ b/src/Roadmap/index.tsx
@@ -154,7 +154,7 @@ export const Roadmap: React.FC<Props> = ({
         stickyColumns={columns.length}
         size="l"
         borderBetweenColumns
-        zebraStriped="odd"
+        zebraStriped="even"
       />
     </div>
   )

--- a/src/_private/storybook/decorators/DocsContainer/index.css
+++ b/src/_private/storybook/decorators/DocsContainer/index.css
@@ -1,0 +1,169 @@
+/* stylelint-disable */
+.main {
+  --width-default: 700px;
+  background: var(--color-bg-default);
+
+  .wrapper {
+    font-family: var(--font-primary);
+
+    max-width: var(--width-default);
+    margin-right: auto;
+    margin-left: auto;
+
+    color: var(--color-typo-primary);
+  }
+
+  [class*='docblock-source'] {
+    background: var(--color-bg-secondary) !important;
+  }
+
+  [class*='sbdocs-wrapper '] {
+    background: transparent !important;
+  }
+
+  h1 {
+    font-size: var(--size-text-4xl);
+
+    margin-bottom: 0.4em;
+  }
+
+  h2 {
+    font-size: var(--size-text-3xl);
+
+    padding-bottom: 0;
+
+    border-bottom: none;
+  }
+
+  h3 {
+    font-size: var(--size-text-2xl);
+  }
+
+  h4 {
+    font-size: var(--size-text-l);
+  }
+
+  p {
+    font-size: var(--size-text-m);
+    line-height: var(--line-height-text-l);
+
+    margin-top: 0;
+    margin-bottom: 1em;
+
+    a {
+      font-size: inherit;
+    }
+  }
+
+  a {
+    font-size: var(--size-text-m);
+    line-height: var(--line-height-text-l);
+  }
+
+  blockquote {
+    font-size: var(--size-text-m);
+
+    box-sizing: border-box;
+    margin-top: 0;
+    margin-bottom: 1em;
+    padding: 0.8em;
+
+    border-left-color: var(--color-bg-ghost);
+    border-radius: 8px;
+    background-color: var(--color-bg-secondary);
+  }
+
+  /* p code {
+    font-size: var(--size-text-s);
+
+    border: 1px solid var(--color-bg-stripe);
+    background-color: var(--color-bg-ghost);
+  } */
+
+  table {
+    font-size: var(--size-text-s);
+    line-height: var(--line-height-text-s);
+
+    width: 100%;
+
+    background: var(--color-bg-default);
+
+    tr {
+      border-top: 1px solid var(--color-bg-border);
+      background-color: var(--color-bg-secondary) !important;
+    }
+
+    tr th:empty {
+      padding: 0;
+
+      border: none;
+    }
+
+    tr th,
+    tr td {
+      padding: var(--space-xs) var(--space-s);
+    }
+
+    tr th:not(:last-child),
+    tr td:not(:last-child) {
+      border-right: 1px solid var(--color-bg-border);
+    }
+
+    code {
+      font-size: var(--size-text-xs);
+    }
+  }
+
+  ul {
+    box-sizing: border-box;
+    margin-top: 0;
+    margin-bottom: 1.6em;
+    padding-left: var(--space-l);
+  }
+
+  :global {
+    h2.sbdocs-h2,
+    h3.sbdocs-h3,
+    h4.sbdocs-h4 {
+      line-height: var(--line-height-text-xs);
+
+      margin-top: 1.6em;
+      margin-bottom: 0.4em;
+    }
+
+    h1.sbdocs-h1 a[aria-hidden='true'],
+    h2.sbdocs-h2 a[aria-hidden='true'],
+    h3.sbdocs-h3 a[aria-hidden='true'],
+    h4.sbdocs-h4 a[aria-hidden='true'] {
+      position: absolute;
+      top: 50%;
+      left: 0;
+
+      display: flex;
+      float: none;
+      align-items: center;
+
+      margin-left: 0;
+      padding: var(--space-xs);
+
+      transform: translate(-100%, -50%);
+    }
+
+    h1 + h2.sbdocs-h2,
+    h2 + h3.sbdocs-h3,
+    h3 + h4.sbdocs-h4,
+    h1 + div + h2.sbdocs-h2,
+    h2 + div + h3.sbdocs-h3,
+    h3 + div + h4.sbdocs-h4 {
+      margin-top: 0.2em;
+    }
+
+    pre.sbdocs > div {
+      font-size: var(--size-text-m);
+
+      margin-top: 0;
+      margin-bottom: 2.2em;
+    }
+  }
+}
+/* stylelint-enable */

--- a/src/_private/storybook/decorators/DocsContainer/index.tsx
+++ b/src/_private/storybook/decorators/DocsContainer/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import { presetGpnDisplay, Theme } from '@consta/uikit/Theme'
+import { DocsContainer } from '@storybook/addon-docs/dist/blocks'
+
+import css from './index.css'
+
+type DocsContainerProps = React.ComponentProps<typeof DocsContainer>
+
+export const DocsDecorator: React.FC<DocsContainerProps> = props => {
+  const { children, context } = props
+
+  return (
+    <Theme preset={presetGpnDisplay} className={css.main}>
+      <DocsContainer context={context}>
+        <div className={css.wrapper}>{children}</div>
+      </DocsContainer>
+    </Theme>
+  )
+}


### PR DESCRIPTION
* add decorator for docs
* add add docs example

добавил декоратор для доки, 
в стилях декоратора есть `stylelint-disable`, связано с тем что линтер не давал использовать вложенные тэги, а они нужны чтобы доопределить стили элементов документации

Создал пример, для того чтобы @arhayka, могла по образу и подобию заполнить документацию

## Чек-лист
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [ ] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение
