### PR TITLE
TSUB-1337: Виджеты: падает барчарт при динамической смене количества групп

### DIFF
--- a/src/BarChart/__tests__/index.test.tsx
+++ b/src/BarChart/__tests__/index.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+
+import { BarChart } from '../'
+
+describe('BarChart', () => {
+  it('не крашится при динамической смене количества групп', () => {
+    const commonProps = {
+      colors: ['var(--color-bg-normal)', 'var(--color-bg-alert)', 'var(--color-bg-warning)'],
+      gridTicks: 5,
+      valuesTicks: 1,
+    }
+
+    const barChart = TestRenderer.create(
+      <BarChart
+        {...commonProps}
+        groups={[
+          {
+            groupName: 'март',
+            values: [410, 600, 270],
+          },
+          {
+            groupName: 'апрель',
+            values: [670, 1000, 1100],
+          },
+          {
+            groupName: 'май',
+            values: [1200, 630, 100],
+          },
+        ]}
+      />
+    )
+
+    expect(() => {
+      barChart.update(
+        <BarChart
+          {...commonProps}
+          groups={[
+            {
+              groupName: 'март',
+              values: [410],
+            },
+            {
+              groupName: 'апрель',
+              values: [670],
+            },
+          ]}
+        />
+      )
+    }).not.toThrow()
+  })
+})

--- a/src/_private/components/BarChart/components/Group/index.tsx
+++ b/src/_private/components/BarChart/components/Group/index.tsx
@@ -57,8 +57,6 @@ export const Group: React.FC<Props> = props => {
     className,
     style,
   } = props
-  const columnsRef = React.useRef<HTMLDivElement>(null)
-
   const renderColumn = (column: ColumnItem | undefined, index: number, isReversed?: boolean) => {
     if (!column) {
       return null
@@ -95,7 +93,7 @@ export const Group: React.FC<Props> = props => {
       className={classnames(css.group, isHorizontal && css.isHorizontal, className)}
       style={style}
     >
-      <div ref={columnsRef} className={css.columns}>
+      <div className={css.columns}>
         <div className={css.wrapper}>
           {columns.map((column, index) => renderColumn(column, index))}
         </div>

--- a/src/_private/components/BarChart/components/Ticks/helpers.ts
+++ b/src/_private/components/BarChart/components/Ticks/helpers.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { TextPropAlign } from '@consta/uikit/Text'
 
 export const SLANTED_TEXT_MAX_LENGTH = 20

--- a/src/_private/components/BarChart/renders.tsx
+++ b/src/_private/components/BarChart/renders.tsx
@@ -53,4 +53,4 @@ export type RenderGroup<T> = (props: {
   onChangeLabelSize?: (size: number) => void
 }) => React.ReactNode
 
-export const defaultRenderGroup: RenderGroup<GroupItem> = Group
+export const defaultRenderGroup: RenderGroup<GroupItem> = props => <Group {...props} />


### PR DESCRIPTION
## Чек-лист
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [ ] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение
