### PR TITLE
GDC-890: Разобраться с правилом ban-types: consta-widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@babel/cli": "7.10.5",
     "@babel/plugin-transform-react-jsx": "7.3.0",
     "@babel/preset-typescript": "7.10.4",
-    "@consta/widgets-configs": "1.1.4",
+    "@consta/widgets-configs": "1.2.0",
     "@mdx-js/loader": "1.5.9",
     "@storybook/addon-actions": "5.3.18",
     "@storybook/addon-docs": "5.3.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2255,10 +2255,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@consta/widgets-configs@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@consta/widgets-configs/-/widgets-configs-1.1.4.tgz#9921e6a09b7a942f077117456b56554765d7ac56"
-  integrity sha512-WpevKotTgMVFdr6EYCto1qmMWt9ARFIRRgls0GlDfvLUZg6xUjudfTT9HIL2vhx7ZK2UMFpWdOd8ysHWzh9KjQ==
+"@consta/widgets-configs@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@consta/widgets-configs/-/widgets-configs-1.2.0.tgz#494d4ec511ae39d39a086500f9eb4c32f792038e"
+  integrity sha512-y4gQnDASPFZe7TnQJw2uCZKNqdMtn+aiTTcQZyRGbgxQuaeZh+VByxK4eZ32lKtimp4rMoSONnj9JHDElFm7gw==
   dependencies:
     "@babel/core" "7.4.5"
     "@babel/plugin-proposal-class-properties" "7.4.4"


### PR DESCRIPTION
- обновил версию consta-widgets-configs для того чтобы применялся новый конфиг eslint
## Чек-лист
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [ ] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение
