### PR TITLE
GDC-925: Барчарт с накоплениями: Сдвигаются направляющие при показе значений

### DIFF
--- a/src/BackgroundBarChart/components/Group/index.css
+++ b/src/BackgroundBarChart/components/Group/index.css
@@ -1,9 +1,6 @@
 .main {
   --background-column-size: 24px;
 
-  position: absolute;
-  bottom: 0;
-
   height: 100%;
 
   &.isHorizontal {
@@ -11,33 +8,30 @@
     bottom: auto;
 
     width: 100%;
-    height: auto;
+    height: var(--background-column-size);
   }
 }
 
 .columns {
   position: relative;
+
+  align-items: center;
+  justify-content: center;
+
+  height: 100%;
 }
 
 .baseColumn {
-  position: absolute;
-  left: 50%;
-
   height: 100%;
 
-  transform: translateX(-50%);
-
   .isHorizontal & {
-    top: 50%;
-    left: auto;
-
     width: 100%;
-
-    transform: translateY(-50%);
   }
 }
 
 .backgroundColumn {
+  position: absolute;
+
   display: flex;
   align-items: center;
   flex-direction: column-reverse;
@@ -46,8 +40,6 @@
 
   .isHorizontal & {
     flex-direction: row;
-
-    height: var(--background-column-size);
   }
 }
 

--- a/src/BackgroundBarChart/index.tsx
+++ b/src/BackgroundBarChart/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { CoreBarChart, Threshold, UnitPosition } from '@/_private/components/BarChart'
 import { Ticks } from '@/_private/components/BarChart/components/Ticks'
+import { GRID_GAP_SPACE } from '@/_private/components/BarChart/helpers'
 import { FormatValue } from '@/_private/types'
 import { ColumnItem as BaseColumnItem } from '@/MultiBarChart'
 
@@ -54,6 +55,8 @@ export const BackgroundBarChart: React.FC<Props> = props => {
   return (
     <CoreBarChart
       {...rest}
+      gridRowGap={GRID_GAP_SPACE.s}
+      gridColumnGap={GRID_GAP_SPACE.m}
       size="m"
       groups={commonGroups}
       valuesDomain={valuesDomain}

--- a/src/SludgeChart/index.tsx
+++ b/src/SludgeChart/index.tsx
@@ -33,6 +33,7 @@ export const SludgeChart: React.FC<Props> = ({ groups, ...rest }) => {
   return (
     <CoreBarChart
       {...rest}
+      gridRowGap={0}
       groups={commonGroups}
       groupsDomain={groupsDomain}
       valuesDomain={valuesDomain}
@@ -41,7 +42,6 @@ export const SludgeChart: React.FC<Props> = ({ groups, ...rest }) => {
       valuesTicks={0}
       size="l"
       isHorizontal
-      isDense
       renderGroup={defaultRenderGroup}
     />
   )

--- a/src/_private/components/BarChart/__tests__/index.test.ts
+++ b/src/_private/components/BarChart/__tests__/index.test.ts
@@ -6,6 +6,8 @@ import {
   getCommonGroupsMaxColumns,
   getEveryNTick,
   getGraphStepSize,
+  getGridColumnGap,
+  getGridRowGap,
   getGridSettings,
   getGroupsDomain,
   getLabelGridAreaName,
@@ -592,5 +594,27 @@ describe('getCommonGroupsMaxColumns', () => {
     ])
 
     expect(result).toEqual(3)
+  })
+})
+
+describe('getGridRowGap', () => {
+  it('получение отступов для грида', () => {
+    expect(getGridRowGap('s')).toEqual('var(--space-2xs)')
+    expect(getGridRowGap('m')).toEqual('var(--space-xs)')
+    expect(getGridRowGap('l')).toEqual('var(--space-xs)')
+  })
+
+  it('получение отступов для горизонтального грида', () => {
+    expect(getGridRowGap('s', true)).toEqual('var(--space-xs)')
+    expect(getGridRowGap('m', true)).toEqual('var(--space-m)')
+    expect(getGridRowGap('l', true)).toEqual('var(--space-xs)')
+  })
+})
+
+describe('getGridColumnGap', () => {
+  it('получение отступов для грида', () => {
+    expect(getGridColumnGap('s')).toEqual('var(--space-xs)')
+    expect(getGridColumnGap('m')).toEqual('var(--space-m)')
+    expect(getGridColumnGap('l')).toEqual('var(--space-m)')
   })
 })

--- a/src/_private/components/BarChart/helpers.ts
+++ b/src/_private/components/BarChart/helpers.ts
@@ -275,3 +275,34 @@ export const getCommonGroupsMaxColumns = (groups: readonly GroupItem[]) => {
     ...groups.map(group => Math.max(group.columns.length, group.reversedColumns.length))
   )
 }
+
+export const GRID_GAP_SPACE = {
+  '2xs': 'var(--space-2xs)',
+  xs: 'var(--space-xs)',
+  m: 'var(--space-m)',
+  s: 'var(--space-s)',
+}
+
+export const getGridRowGap = (axisSize: Size, isHorizontal?: boolean): string => {
+  if (isHorizontal && axisSize === 's') {
+    return GRID_GAP_SPACE.xs
+  }
+
+  if (isHorizontal && axisSize === 'm') {
+    return GRID_GAP_SPACE.m
+  }
+
+  if (axisSize === 's') {
+    return GRID_GAP_SPACE['2xs']
+  }
+
+  return GRID_GAP_SPACE.xs
+}
+
+export const getGridColumnGap = (axisSize: Size): string => {
+  if (axisSize === 's') {
+    return GRID_GAP_SPACE.xs
+  }
+
+  return GRID_GAP_SPACE.m
+}

--- a/src/_private/components/BarChart/index.css
+++ b/src/_private/components/BarChart/index.css
@@ -17,9 +17,6 @@
 }
 
 .chart {
-  --grid-row-gap: var(--space-xs);
-  --grid-column-gap: var(--space-m);
-
   position: relative;
 
   display: grid;
@@ -27,34 +24,8 @@
 
   box-sizing: border-box;
 
-  grid-gap: var(--grid-row-gap) var(--grid-column-gap);
-
-  &.asixSizeS {
-    --grid-row-gap: var(--space-2xs);
-    --grid-column-gap: var(--space-xs);
-  }
-
-  &.asixSizeM {
-    --grid-row-gap: var(--space-xs);
-    --grid-column-gap: var(--space-m);
-  }
-
-  &.isHorizontal.asixSizeS {
-    --grid-row-gap: var(--space-xs);
-    --grid-column-gap: var(--space-xs);
-  }
-
-  &.isHorizontal.asixSizeM {
-    --grid-row-gap: var(--space-m);
-    --grid-column-gap: var(--space-m);
-  }
-
   &.isHorizontal {
     padding-right: var(--space-m);
-  }
-
-  &.isDense {
-    --grid-row-gap: 0;
   }
 
   &.columnSizeS {

--- a/src/_private/components/BarChart/index.tsx
+++ b/src/_private/components/BarChart/index.tsx
@@ -3,7 +3,6 @@ import React, { useLayoutEffect, useRef, useState } from 'react'
 import { useComponentSize } from '@consta/uikit/useComponentSize'
 import { Text, TextPropSize } from '@consta/uikit/Text'
 import classnames from 'classnames'
-import _ from 'lodash'
 
 import { Grid } from '@/_private/components/Grid'
 import { FormatValue } from '@/_private/types'
@@ -20,6 +19,8 @@ import {
   GetAxisShowPositions,
   getColumnSize,
   getEveryNTick,
+  getGridColumnGap,
+  getGridRowGap,
   getGridSettings,
   getLabelGridAreaName,
   getRange,
@@ -78,6 +79,8 @@ export type Props<T> = {
   renderAxisValues?: RenderAxisValues
   onMouseEnterColumn?: OnMouseHoverColumn
   onMouseLeaveColumn?: OnMouseHoverColumn
+  gridRowGap?: number | string
+  gridColumnGap?: number | string
 }
 
 const unitSize: Record<TicksSize, TextPropSize> = {
@@ -100,12 +103,6 @@ const axisTicksPositionsClasses = {
   bottom: css.bottomTicks,
   right: css.rightTicks,
   top: css.topTicks,
-}
-
-const axisSizeClasses: Record<TicksSize, string> = {
-  s: css.asixSizeS,
-  m: css.asixSizeM,
-  l: css.asixSizeM,
 }
 
 const renderUnit = (className: string, unit: string, size: TicksSize) => (
@@ -142,6 +139,8 @@ export const CoreBarChart = <T,>(props: Props<T>) => {
     isXAxisLabelsSlanted,
     onMouseEnterColumn,
     onMouseLeaveColumn,
+    gridRowGap,
+    gridColumnGap,
   } = props
   const ref = useRef<HTMLDivElement>(null)
   const svgRef = useRef(null)
@@ -283,6 +282,10 @@ export const CoreBarChart = <T,>(props: Props<T>) => {
   const showUnitBottom =
     unitPosition !== 'none' && (unitPosition === 'bottom' || unitPosition === 'left-and-bottom')
 
+  const axisSize = toAxisSize(columnSize)
+  const computedGridRowGap = gridRowGap ?? getGridRowGap(axisSize, isHorizontal)
+  const computedGridColumnGap = gridColumnGap ?? getGridColumnGap(axisSize)
+
   /**
    * Из за различий в построении осей для горизонтального и вертикального режима
    * пришлось задублировать рендер axisShowPositions
@@ -297,8 +300,6 @@ export const CoreBarChart = <T,>(props: Props<T>) => {
         className={classnames(
           css.chart,
           isHorizontal && css.isHorizontal,
-          isDense && css.isDense,
-          size && axisSizeClasses[toAxisSize(columnSize)],
           columnSizeClasses[columnSize]
         )}
         style={{
@@ -310,6 +311,7 @@ export const CoreBarChart = <T,>(props: Props<T>) => {
             maxColumn,
             axisShowPositions,
           }),
+          gridGap: `${computedGridRowGap} ${computedGridColumnGap}`,
         }}
       >
         <svg className={css.svg} ref={svgRef} style={gridStyle}>
@@ -330,7 +332,7 @@ export const CoreBarChart = <T,>(props: Props<T>) => {
             />
           )}
         </svg>
-        {unit && showUnitLeft && renderUnit(css.topLeftUnit, unit, toAxisSize(columnSize))}
+        {unit && showUnitLeft && renderUnit(css.topLeftUnit, unit, axisSize)}
         {!isHorizontal && axisShowPositions.top && renderHorizontal('top')}
         {axisShowPositions.right && renderVertical('right')}
         {groups.map((group, groupIdx) => {
@@ -374,7 +376,7 @@ export const CoreBarChart = <T,>(props: Props<T>) => {
         })}
         {axisShowPositions.left && renderVertical('left')}
         {!isHorizontal && axisShowPositions.bottom && renderHorizontal('bottom')}
-        {unit && showUnitBottom && renderUnit(css.bottomUnit, unit, toAxisSize(columnSize))}
+        {unit && showUnitBottom && renderUnit(css.bottomUnit, unit, axisSize)}
       </div>
       {isHorizontal && axisShowPositions.bottom && renderHorizontal('bottom')}
       {tooltipData && (


### PR DESCRIPTION
## Чек-лист
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [x] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение

У **CoreBarChart** вынес в props функцию, которая высчитывает padding. Так как для **BackgroundBarChart** падинги не нужны при включенном showValues. Для остальных компонентов которые используют **CoreBarChart** используется таже логика, что и была.