### PR TITLE
GDC-773: Барчарт. Минимальные размеры столбцов

### DIFF
--- a/src/_private/components/BarChart/index.css
+++ b/src/_private/components/BarChart/index.css
@@ -124,4 +124,8 @@
 
 .groupWrapper {
   position: relative;
+
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
GDC-773: Барчарт. Минимальные размеры столбцов после рефреша на минимальном размере

Проблема: Компонент не до конца прорисовался и из-за этого размеры Section заданные в процентах не корректно работали. Помог useLayoutEffect

## Чек-лист
- [ ] Используются размеры/цвета/шрифты/иконки/компоненты из UI-kit
- [ ] Написаны тесты на новые/измененные расчёты
- [ ] Заведена задача на повышение версии компонентов, если нужно будет где-то их обновить
- [ ] Оставлены комментарии в тех местах, где требуется пояснить, почему было принято такое решение

